### PR TITLE
Add responsive Corre por México landing page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,678 @@
+:root {
+    --color-green: #1f9d55;
+    --color-green-dark: #0f6d3b;
+    --color-red: #c81d25;
+    --color-red-dark: #8a1018;
+    --color-cream: #f6f1eb;
+    --color-white: #ffffff;
+    --color-gray: #3b3b3b;
+    --color-gray-light: #d9d9d9;
+    --color-shadow: rgba(0, 0, 0, 0.08);
+    --font-body: 'Nunito', sans-serif;
+    --font-display: 'Pacifico', cursive;
+    --border-radius: 18px;
+    --transition: 0.3s ease;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-body);
+    background: linear-gradient(180deg, rgba(246, 241, 235, 0.9) 0%, rgba(255, 255, 255, 0.9) 100%);
+    color: var(--color-gray);
+    line-height: 1.6;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+    outline: 3px solid var(--color-red);
+    outline-offset: 2px;
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background-color: var(--color-green);
+    color: var(--color-white);
+    padding: 0.75rem 1.5rem;
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    z-index: 1000;
+    transition: top var(--transition);
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(6px);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1.5rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.logo img {
+    width: 48px;
+    height: 48px;
+}
+
+.logo-title {
+    font-family: var(--font-display);
+    font-size: 1.5rem;
+    color: var(--color-red);
+}
+
+.logo-tagline {
+    font-size: 0.85rem;
+    color: var(--color-green-dark);
+}
+
+.main-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+.main-nav a {
+    font-weight: 600;
+    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    transition: background-color var(--transition), color var(--transition);
+}
+
+.main-nav a:hover,
+.main-nav a:focus-visible {
+    background-color: var(--color-green);
+    color: var(--color-white);
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--color-green-dark);
+}
+
+.lang-toggle {
+    border: 2px solid var(--color-green);
+    background: var(--color-white);
+    color: var(--color-green-dark);
+    padding: 0.4rem 0.8rem;
+    border-radius: 999px;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.cta {
+    background: var(--color-red);
+    color: var(--color-white);
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    font-weight: 700;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.cta:hover,
+.cta:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px var(--color-shadow);
+}
+
+.hero {
+    display: grid;
+    gap: 2rem;
+    padding: 2.5rem 1.5rem 3.5rem;
+    background: url('https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+    color: var(--color-white);
+    position: relative;
+    overflow: hidden;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(31, 157, 85, 0.85), rgba(200, 29, 37, 0.85));
+    z-index: 0;
+}
+
+.hero-content,
+.hero-illustration {
+    position: relative;
+    z-index: 1;
+}
+
+.hero-content h1 {
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 1rem;
+}
+
+.hero-content p {
+    max-width: 32rem;
+    font-size: 1.1rem;
+}
+
+.hero-actions {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.btn {
+    border: none;
+    border-radius: 999px;
+    padding: 0.75rem 1.5rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background-color var(--transition);
+}
+
+.btn.primary {
+    background: var(--color-green);
+    color: var(--color-white);
+}
+
+.btn.primary:hover,
+.btn.primary:focus-visible {
+    background: var(--color-green-dark);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px var(--color-shadow);
+}
+
+.btn.secondary {
+    background: var(--color-white);
+    color: var(--color-green-dark);
+    border: 2px solid transparent;
+}
+
+.btn.secondary:hover,
+.btn.secondary:focus-visible {
+    border-color: var(--color-white);
+    transform: translateY(-1px);
+}
+
+.btn.tertiary {
+    background: rgba(255, 255, 255, 0.2);
+    color: var(--color-gray);
+}
+
+.btn.download {
+    background: var(--color-red);
+    color: var(--color-white);
+    width: 100%;
+    margin-top: 1rem;
+}
+
+.section-heading {
+    text-align: center;
+    padding: 3rem 1.5rem 1.5rem;
+}
+
+.section-heading h2 {
+    font-size: clamp(1.8rem, 3vw, 2.5rem);
+    margin-bottom: 0.5rem;
+}
+
+.filters {
+    padding: 0 1.5rem 2rem;
+}
+
+.filters-form {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    background: var(--color-white);
+    padding: 1.5rem;
+    border-radius: var(--border-radius);
+    box-shadow: 0 20px 40px var(--color-shadow);
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.form-group label {
+    font-weight: 700;
+    color: var(--color-green-dark);
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+    border: 1px solid rgba(31, 157, 85, 0.2);
+    border-radius: 12px;
+    padding: 0.65rem 0.85rem;
+    font-size: 1rem;
+    font-family: inherit;
+    background: rgba(255, 255, 255, 0.95);
+}
+
+.form-group.full-width {
+    grid-column: 1 / -1;
+}
+
+.form-actions {
+    display: flex;
+    gap: 1rem;
+    grid-column: 1 / -1;
+    flex-wrap: wrap;
+}
+
+.filters-help {
+    grid-column: 1 / -1;
+    color: var(--color-green-dark);
+    font-style: italic;
+}
+
+.results {
+    padding: 2rem 1.5rem 3rem;
+}
+
+.results-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.results-count {
+    font-weight: 700;
+    color: var(--color-green-dark);
+}
+
+.view-toggle {
+    display: inline-flex;
+    background: var(--color-white);
+    border-radius: 999px;
+    box-shadow: 0 12px 24px var(--color-shadow);
+    overflow: hidden;
+}
+
+.view-toggle .btn {
+    border-radius: 0;
+    padding: 0.6rem 1.4rem;
+}
+
+.view-toggle .btn[aria-pressed="true"] {
+    background: var(--color-green);
+    color: var(--color-white);
+}
+
+.results-body {
+    background: var(--color-white);
+    border-radius: var(--border-radius);
+    box-shadow: 0 20px 40px var(--color-shadow);
+    overflow: hidden;
+}
+
+.list-view {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    padding: 2rem;
+}
+
+.card {
+    background: var(--color-white);
+    border-radius: var(--border-radius);
+    box-shadow: 0 14px 30px var(--color-shadow);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.card h3 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: var(--color-red);
+}
+
+.card p {
+    margin: 0;
+}
+
+.race-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.race-image {
+    border-radius: 14px;
+    height: 180px;
+    object-fit: cover;
+    width: 100%;
+}
+
+.race-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-green-dark);
+}
+
+.race-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: auto;
+}
+
+.badge {
+    background: rgba(31, 157, 85, 0.15);
+    color: var(--color-green-dark);
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 0.8rem;
+}
+
+.map-view {
+    height: 500px;
+}
+
+#race-map {
+    width: 100%;
+    height: 100%;
+}
+
+.hidden {
+    display: none;
+}
+
+.calendar {
+    padding: 3rem 1.5rem;
+}
+
+.calendar-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.calendar-panel {
+    background: var(--color-white);
+    border-radius: var(--border-radius);
+    box-shadow: 0 16px 32px var(--color-shadow);
+    padding: 1.75rem;
+}
+
+.favorites-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.favorite-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: rgba(31, 157, 85, 0.08);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+}
+
+.favorite-item > div {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.favorites-empty {
+    font-style: italic;
+    color: var(--color-green-dark);
+}
+
+.organizers {
+    padding: 3rem 1.5rem;
+}
+
+.organizer-form {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    background: var(--color-white);
+    padding: 2rem;
+    border-radius: var(--border-radius);
+    box-shadow: 0 20px 40px var(--color-shadow);
+}
+
+.form-help {
+    grid-column: 1 / -1;
+    color: var(--color-green-dark);
+    font-size: 0.95rem;
+}
+
+.community {
+    padding: 3rem 1.5rem;
+}
+
+.community-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonials {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.payments {
+    padding: 3rem 1.5rem;
+}
+
+.payment-methods {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.payment-card {
+    background: var(--color-white);
+    border-radius: var(--border-radius);
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-weight: 700;
+    box-shadow: 0 14px 28px var(--color-shadow);
+}
+
+.payment-card i {
+    font-size: 1.5rem;
+    color: var(--color-red);
+}
+
+.support {
+    padding: 3rem 1.5rem 4rem;
+}
+
+.support-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.support-card {
+    background: var(--color-white);
+    border-radius: var(--border-radius);
+    padding: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 700;
+    color: var(--color-green-dark);
+    box-shadow: 0 12px 24px var(--color-shadow);
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.support-card:hover,
+.support-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 35px var(--color-shadow);
+}
+
+.site-footer {
+    background: var(--color-green-dark);
+    color: var(--color-white);
+    padding: 3rem 1.5rem;
+}
+
+.footer-content {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.footer-links,
+.footer-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.footer-links a {
+    color: var(--color-white);
+    text-decoration: underline;
+}
+
+.cookie-banner {
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-white);
+    padding: 1rem 1.5rem;
+    border-radius: var(--border-radius);
+    box-shadow: 0 16px 32px var(--color-shadow);
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    max-width: 90%;
+    z-index: 200;
+}
+
+.cookie-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 900px) {
+    .site-header {
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .main-nav {
+        display: none;
+        width: 100%;
+    }
+
+    .main-nav.open {
+        display: block;
+        animation: fadeIn var(--transition) ease;
+    }
+
+    .main-nav ul {
+        flex-direction: column;
+    }
+
+    .menu-toggle {
+        display: block;
+    }
+
+    .hero {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .hero-actions {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/assets/img/logo-placeholder.svg
+++ b/assets/img/logo-placeholder.svg
@@ -1,0 +1,13 @@
+<svg width="72" height="72" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Corre por México</title>
+  <desc id="desc">Logotipo circular con figura de corredor estilizada.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f9d55" />
+      <stop offset="100%" stop-color="#c81d25" />
+    </linearGradient>
+  </defs>
+  <circle cx="36" cy="36" r="34" fill="url(#grad)" stroke="#ffffff" stroke-width="2" />
+  <path d="M18 42c6-10 12-12 16-12 6 0 10 4 10 8s-4 8-10 8c-4 0-10-2-16-4z" fill="#ffffff" opacity="0.85" />
+  <path d="M46 22l8 8-4 4-8-8z" fill="#ffffff" opacity="0.85" />
+</svg>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,673 @@
+const translations = {
+    es: {
+        siteName: "Corre por México",
+        siteTagline: "La plataforma que conecta a la banda corredora",
+        openMenu: "Abrir menú",
+        navExplore: "Explora carreras",
+        navMap: "Mapa",
+        navCommunity: "Comunidad",
+        navOrganizers: "Organizadores",
+        navSupport: "Soporte",
+        ctaJoin: "Inscríbete ahora",
+        heroTitle: "Encuentra carreras chidas en todo México",
+        heroSubtitle: "Conecta con la comunidad corredora, arma tu calendario y vive cada meta como si fuera una fiesta.",
+        heroExplore: "Explora carreras",
+        heroCommunity: "Únete a la banda",
+        filtersTitle: "Busca tu siguiente reto",
+        filtersDescription: "Usa el buscador avanzado para encontrar carreras por estado, distancia, fecha y nivel. ¡Hay opciones para toda la familia!",
+        filterState: "Estado",
+        filterType: "Tipo de carrera",
+        filterDistance: "Distancia",
+        filterDifficulty: "Dificultad",
+        filterDate: "Fecha",
+        filterKeywords: "Palabras clave",
+        filterKeywordsPlaceholder: "Busca por ciudad, nombre o vibes",
+        filterApply: "Aplicar filtros",
+        filterReset: "Limpiar",
+        filtersHelp: "Puedes combinar varios filtros para encontrar la carrera perfecta.",
+        optionAny: "Cualquiera",
+        difficultyBeginner: "Principiante",
+        difficultyIntermediate: "Intermedia",
+        difficultyAdvanced: "Avanzada",
+        resultsTitle: "Resultados destacados",
+        viewList: "Vista lista",
+        viewMap: "Vista mapa",
+        calendarTitle: "Tu calendario y favoritos",
+        calendarDescription: "Guarda carreras, descarga tu plan en PDF o iCal y recibe recordatorios por correo o WhatsApp.",
+        favoritesTitle: "Tus carreras favoritas",
+        favoritesEmpty: "Aún no tienes favoritas. Guarda tus carreras top para no olvidarlas.",
+        remindersTitle: "Recordatorios personalizados",
+        reminderEmail: "Correo electrónico",
+        reminderWhatsApp: "WhatsApp (opcional)",
+        reminderFrequency: "Frecuencia de avisos",
+        reminderWeekly: "Semanal",
+        reminderBiweekly: "Cada 15 días",
+        reminderMonthly: "Mensual",
+        reminderSubmit: "Recibir recordatorios",
+        downloadCalendar: "Descargar calendario (iCal)",
+        organizersTitle: "Zona para organizadores",
+        organizersDescription: "Registra tus carreras con toda la información necesaria. Nosotros nos encargamos de difundirla con la comunidad corredora.",
+        organizerRaceName: "Nombre del evento",
+        organizerLocation: "Lugar",
+        organizerDate: "Fecha",
+        organizerTypes: "Tipos de carrera",
+        organizerDistances: "Distancias",
+        organizerPrices: "Rango de precios",
+        organizerLink: "Enlace de inscripción",
+        organizerImages: "Imágenes del evento",
+        organizerSponsors: "Patrocinadores",
+        organizerDescription: "Descripción y beneficios",
+        organizerSubmit: "Enviar carrera",
+        organizersHelp: "Nuestro equipo revisará la información para asegurar el cumplimiento con PROFECO y CONAR.",
+        communityTitle: "Comunidad y entrenamiento",
+        communityDescription: "Historias, tips de entrenamiento, foros de preguntas y testimonios que inspiran a correr en tribu.",
+        communityBlogTitle: "Blog y artículos",
+        communityBlogDescription: "Lee guías de entrenamientos, nutrición y carreras legendarias, con lenguaje cercano y ejemplos de todo México.",
+        communityBlogCta: "Ir al blog",
+        communityForumTitle: "Foros y preguntas",
+        communityForumDescription: "Comparte dudas, arma tus grupos de entrenamiento y recibe apoyo de la banda en tu región.",
+        communityForumCta: "Entrar a los foros",
+        communityTestimonialsTitle: "Testimonios chidos",
+        testimonial1: "“Gracias a Corre por México corrí mi primer 10K en Oaxaca. La vibra fue increíble.”",
+        testimonial2: "“La comunidad me ayudó a armar mi calendario trail en Chihuahua. ¡Pura buena onda!”",
+        paymentsTitle: "Pagos flexibles y locales",
+        paymentsDescription: "Aceptamos tarjetas, SPEI, PayPal, OXXO y 7-Eleven para que puedas inscribirte sin complicaciones.",
+        paymentCard: "Tarjeta de crédito y débito",
+        paymentSpei: "Transferencia SPEI",
+        paymentOxxo: "Pagos en OXXO",
+        paymentSeven: "Pagos en 7-Eleven",
+        supportTitle: "Soporte y redes sociales",
+        supportDescription: "Comparte carreras, recibe ayuda y mantente al día con nuestras redes.",
+        footerTitle: "Corre por México",
+        footerDescription: "Celebramos la diversidad de rutas, culturas y tradiciones que hacen grande a nuestra comunidad corredora.",
+        footerPrivacy: "Aviso de Privacidad",
+        footerTerms: "Términos y Condiciones",
+        footerCookies: "Cookies y preferencias",
+        footerAccessibility: "Accesibilidad",
+        footerRights: "© {year} Corre por México. Todos los derechos reservados.",
+        footerCompliance: "Cumplimos con la normatividad de PROFECO y CONAR para proteger a nuestra comunidad.",
+        cookiesMessage: "Usamos cookies para mejorar tu experiencia y cumplir con la normatividad mexicana. ¿Las aceptas?",
+        cookiesAccept: "Aceptar",
+        cookiesReject: "Configurar",
+        toggleLang: "Cambiar idioma",
+        saveFavorite: "Guardar favorita",
+        removeFavorite: "Quitar favorita",
+        viewDetails: "Más detalles",
+        shareRace: "Compartir",
+        reminderSuccess: "¡Listo! Te enviaremos recordatorios personalizados.",
+        reminderError: "Revisa que tu correo sea válido para recibir recordatorios.",
+        formSuccess: "Tu carrera será revisada y publicada pronto. ¡Gracias por confiar en nosotros!",
+        formError: "Revisa los campos obligatorios antes de enviar.",
+        newsletterCta: "Inscríbete",
+        calendarDownloadSuccess: "Tu archivo de calendario está listo.",
+        favoritesShare: "Compartir por WhatsApp"
+    },
+    en: {
+        siteName: "Run Across Mexico",
+        siteTagline: "The hub that brings the running crew together",
+        openMenu: "Open menu",
+        navExplore: "Explore races",
+        navMap: "Map",
+        navCommunity: "Community",
+        navOrganizers: "Organizers",
+        navSupport: "Support",
+        ctaJoin: "Register now",
+        heroTitle: "Find epic races across Mexico",
+        heroSubtitle: "Connect with the running crew, build your calendar, and celebrate every finish line like a fiesta.",
+        heroExplore: "Explore races",
+        heroCommunity: "Join the crew",
+        filtersTitle: "Find your next challenge",
+        filtersDescription: "Use the advanced search to discover races by state, distance, date, and level. Options for the whole family!",
+        filterState: "State",
+        filterType: "Race type",
+        filterDistance: "Distance",
+        filterDifficulty: "Difficulty",
+        filterDate: "Date",
+        filterKeywords: "Keywords",
+        filterKeywordsPlaceholder: "Search by city, name, or vibes",
+        filterApply: "Apply filters",
+        filterReset: "Clear",
+        filtersHelp: "Mix filters to match the perfect race for you.",
+        optionAny: "Any",
+        difficultyBeginner: "Beginner",
+        difficultyIntermediate: "Intermediate",
+        difficultyAdvanced: "Advanced",
+        resultsTitle: "Featured results",
+        viewList: "List view",
+        viewMap: "Map view",
+        calendarTitle: "Your calendar and favorites",
+        calendarDescription: "Save races, download your plan in PDF or iCal, and get reminders by email or WhatsApp.",
+        favoritesTitle: "Your favorite races",
+        favoritesEmpty: "No favorites yet. Save your top races so you won't forget them.",
+        remindersTitle: "Personalized reminders",
+        reminderEmail: "Email",
+        reminderWhatsApp: "WhatsApp (optional)",
+        reminderFrequency: "Reminder frequency",
+        reminderWeekly: "Weekly",
+        reminderBiweekly: "Every 2 weeks",
+        reminderMonthly: "Monthly",
+        reminderSubmit: "Get reminders",
+        downloadCalendar: "Download calendar (iCal)",
+        organizersTitle: "Organizer zone",
+        organizersDescription: "Register your races with all the details. We will share them with the running community.",
+        organizerRaceName: "Event name",
+        organizerLocation: "Location",
+        organizerDate: "Date",
+        organizerTypes: "Race types",
+        organizerDistances: "Distances",
+        organizerPrices: "Price range",
+        organizerLink: "Registration link",
+        organizerImages: "Event images",
+        organizerSponsors: "Sponsors",
+        organizerDescription: "Description and perks",
+        organizerSubmit: "Submit race",
+        organizersHelp: "Our team will review the info to comply with PROFECO and CONAR guidelines.",
+        communityTitle: "Community and training",
+        communityDescription: "Stories, training tips, forums, and testimonials to keep you inspired.",
+        communityBlogTitle: "Blog and articles",
+        communityBlogDescription: "Read training guides, nutrition tips, and legendary race stories from all over Mexico.",
+        communityBlogCta: "Go to blog",
+        communityForumTitle: "Forums and questions",
+        communityForumDescription: "Share questions, find training buddies, and get support from your region.",
+        communityForumCta: "Enter forums",
+        communityTestimonialsTitle: "Awesome testimonials",
+        testimonial1: "“Thanks to Run Across Mexico I ran my first 10K in Oaxaca. The vibes were amazing.”",
+        testimonial2: "“The community helped me craft my trail calendar in Chihuahua. So much good energy!”",
+        paymentsTitle: "Local-friendly payments",
+        paymentsDescription: "We accept cards, SPEI, PayPal, OXXO, and 7-Eleven so you can register with ease.",
+        paymentCard: "Credit and debit cards",
+        paymentSpei: "SPEI transfers",
+        paymentOxxo: "Pay at OXXO",
+        paymentSeven: "Pay at 7-Eleven",
+        supportTitle: "Support and social media",
+        supportDescription: "Share races, get help, and stay tuned with our social media.",
+        footerTitle: "Run Across Mexico",
+        footerDescription: "We celebrate the diversity of routes, cultures, and traditions that power our running community.",
+        footerPrivacy: "Privacy notice",
+        footerTerms: "Terms & conditions",
+        footerCookies: "Cookies & preferences",
+        footerAccessibility: "Accessibility",
+        footerRights: "© {year} Run Across Mexico. All rights reserved.",
+        footerCompliance: "We comply with PROFECO and CONAR guidelines to protect our community.",
+        cookiesMessage: "We use cookies to improve your experience and comply with Mexican regulations. Do you accept?",
+        cookiesAccept: "Accept",
+        cookiesReject: "Configure",
+        toggleLang: "Switch language",
+        saveFavorite: "Save favorite",
+        removeFavorite: "Remove favorite",
+        viewDetails: "View details",
+        shareRace: "Share",
+        reminderSuccess: "Done! We'll send you tailored reminders.",
+        reminderError: "Please enter a valid email to receive reminders.",
+        formSuccess: "Your race will be reviewed and published soon. Thanks for trusting us!",
+        formError: "Please check the required fields before sending.",
+        newsletterCta: "Sign up",
+        calendarDownloadSuccess: "Your calendar file is ready.",
+        favoritesShare: "Share on WhatsApp"
+    }
+};
+
+const races = [
+    {
+        id: 1,
+        name: "Maratón CDMX",
+        state: "Ciudad de México",
+        city: "CDMX",
+        type: "Maratón",
+        distances: [42, 21, 10],
+        date: "2024-08-25",
+        difficulty: "advanced",
+        price: "$950 MXN",
+        coordinates: [19.4326, -99.1332],
+        image: "https://images.unsplash.com/photo-1502810190503-8303352c05c4?auto=format&fit=crop&w=1200&q=80",
+        description: "Ruta icónica por el corazón de la capital con animación en cada kilómetro.",
+        tags: ["urbana", "certificada"],
+        url: "https://www.maratoncdmx.com"
+    },
+    {
+        id: 2,
+        name: "Trail de la Sierra Tarahumara",
+        state: "Chihuahua",
+        city: "Creel",
+        type: "Trail",
+        distances: [21, 50],
+        date: "2024-10-12",
+        difficulty: "advanced",
+        price: "$1,200 MXN",
+        coordinates: [27.7512, -107.6358],
+        image: "https://images.unsplash.com/photo-1508609349937-5ec4ae374ebf?auto=format&fit=crop&w=1200&q=80",
+        description: "Corre entre barrancas impresionantes y conecta con la cultura rarámuri.",
+        tags: ["trail", "montaña"],
+        url: "https://example.com/tarahumara"
+    },
+    {
+        id: 3,
+        name: "10K Guadalajara Nocturno",
+        state: "Jalisco",
+        city: "Guadalajara",
+        type: "10K",
+        distances: [10],
+        date: "2024-06-15",
+        difficulty: "intermediate",
+        price: "$550 MXN",
+        coordinates: [20.6597, -103.3496],
+        image: "https://images.unsplash.com/photo-1505322022379-7c3353ee6291?auto=format&fit=crop&w=1200&q=80",
+        description: "Una fiesta nocturna por las calles tapatías con música en vivo.",
+        tags: ["nocturna", "urbana"],
+        url: "https://example.com/guadalajara10k"
+    },
+    {
+        id: 4,
+        name: "5K Familiar Mérida",
+        state: "Yucatán",
+        city: "Mérida",
+        type: "5K",
+        distances: [5],
+        date: "2024-05-10",
+        difficulty: "beginner",
+        price: "$300 MXN",
+        coordinates: [20.9674, -89.5926],
+        image: "https://images.unsplash.com/photo-1508606572321-901ea443707f?auto=format&fit=crop&w=1200&q=80",
+        description: "Carrera inclusiva para toda la familia con post-meta de comida yucateca.",
+        tags: ["familiar", "gastronómica"],
+        url: "https://example.com/merida5k"
+    },
+    {
+        id: 5,
+        name: "Medio Maratón Oaxaca",
+        state: "Oaxaca",
+        city: "Oaxaca",
+        type: "Medio maratón",
+        distances: [21, 10],
+        date: "2024-09-08",
+        difficulty: "intermediate",
+        price: "$700 MXN",
+        coordinates: [17.0594, -96.7216],
+        image: "https://images.unsplash.com/photo-1552674605-db6ffd4facb5?auto=format&fit=crop&w=1200&q=80",
+        description: "Descubre calles coloniales y música tradicional en cada esquina.",
+        tags: ["cultural", "patrimonial"],
+        url: "https://example.com/oaxaca21k"
+    },
+    {
+        id: 6,
+        name: "Ultramaratón Huasteco",
+        state: "San Luis Potosí",
+        city: "Xilitla",
+        type: "Ultra",
+        distances: [60, 80],
+        date: "2024-11-02",
+        difficulty: "advanced",
+        price: "$1,500 MXN",
+        coordinates: [21.3889, -98.9963],
+        image: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80",
+        description: "Rinde homenaje a la Huasteca durante Día de Muertos con paisajes selváticos.",
+        tags: ["cultural", "trail"],
+        url: "https://example.com/huasteco"
+    }
+];
+
+const appState = {
+    lang: localStorage.getItem("cpm-lang") || "es",
+    favorites: JSON.parse(localStorage.getItem("cpm-favorites") || "[]"),
+    map: null,
+    markers: []
+};
+
+const elements = {
+    filtersForm: document.querySelector(".filters-form"),
+    listView: document.querySelector(".list-view"),
+    mapContainer: document.getElementById("race-map"),
+    mapViewWrapper: document.querySelector(".map-view"),
+    resultsCount: document.querySelector(".results-count"),
+    viewToggleButtons: document.querySelectorAll(".view-toggle .btn"),
+    favoritesList: document.querySelector(".favorites-list"),
+    favoritesEmpty: document.querySelector(".favorites-empty"),
+    reminderForm: document.querySelector(".reminder-form"),
+    downloadButton: document.querySelector(".btn.download"),
+    organizerForm: document.querySelector(".organizer-form"),
+    cookieBanner: document.querySelector(".cookie-banner"),
+    langToggle: document.querySelector(".lang-toggle"),
+    menuToggle: document.querySelector(".menu-toggle"),
+    mainNav: document.querySelector(".main-nav"),
+    year: document.getElementById("year")
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+    elements.year.textContent = new Date().getFullYear();
+    applyTranslations();
+    populateFilters();
+    renderResults(races);
+    renderFavorites();
+    initMap();
+    setupEvents();
+    handleCookies();
+});
+
+function applyTranslations() {
+    const lang = appState.lang;
+    const dictionary = translations[lang];
+    document.documentElement.lang = lang === "es" ? "es" : "en";
+    document.querySelectorAll("[data-i18n]").forEach((node) => {
+        const key = node.getAttribute("data-i18n");
+        if (dictionary[key]) {
+            if (key === "footerRights") {
+                node.textContent = dictionary[key].replace("{year}", new Date().getFullYear());
+            } else {
+                node.textContent = dictionary[key];
+            }
+        }
+    });
+
+    document.querySelectorAll("[data-i18n-placeholder]").forEach((node) => {
+        const key = node.getAttribute("data-i18n-placeholder");
+        if (dictionary[key]) {
+            node.setAttribute("placeholder", dictionary[key]);
+        }
+    });
+
+    if (elements.langToggle) {
+        elements.langToggle.dataset.lang = lang;
+        elements.langToggle.querySelector(".lang-label").textContent = lang.toUpperCase();
+    }
+}
+
+function populateFilters() {
+    const stateSelect = document.getElementById("state");
+    const typeSelect = document.getElementById("raceType");
+    const states = [...new Set(races.map((race) => race.state))];
+    const types = [...new Set(races.map((race) => race.type))];
+
+    states.sort().forEach((state) => {
+        const option = document.createElement("option");
+        option.value = state;
+        option.textContent = state;
+        stateSelect.append(option);
+    });
+
+    types.sort().forEach((type) => {
+        const option = document.createElement("option");
+        option.value = type;
+        option.textContent = type;
+        typeSelect.append(option);
+    });
+}
+
+function renderResults(results) {
+    if (!elements.listView) return;
+
+    elements.listView.innerHTML = "";
+    results.forEach((race) => {
+        const article = document.createElement("article");
+        article.className = "card race-card";
+        article.setAttribute("role", "listitem");
+        article.innerHTML = `
+            <header>
+                <div>
+                    <h3>${race.name}</h3>
+                    <div class="race-meta">
+                        <span>${race.city}, ${race.state}</span>
+                        <span>${formatDate(race.date)}</span>
+                        <span>${race.type}</span>
+                        <span>${race.distances.join(" / ")}K</span>
+                    </div>
+                </div>
+                <button class="favorite-btn btn secondary" data-id="${race.id}">
+                    ${isFavorite(race.id) ? translations[appState.lang].removeFavorite : translations[appState.lang].saveFavorite}
+                </button>
+            </header>
+            <img src="${race.image}" alt="${race.name}" loading="lazy" class="race-image" />
+            <p>${race.description}</p>
+            <div class="race-meta">
+                ${race.tags.map((tag) => `<span class="badge">${tag}</span>`).join("")}
+                <span class="badge">${race.price}</span>
+            </div>
+            <div class="race-actions">
+                <a class="btn primary" href="${race.url}" target="_blank" rel="noopener">${translations[appState.lang].viewDetails}</a>
+                <button class="btn secondary share-btn" data-name="${race.name}" data-url="${race.url}">${translations[appState.lang].shareRace}</button>
+            </div>
+        `;
+        elements.listView.append(article);
+    });
+
+    elements.resultsCount.textContent = `${results.length} ${appState.lang === "es" ? "carreras encontradas" : "races found"}`;
+
+    attachFavoriteEvents();
+    attachShareEvents();
+    updateMapMarkers(results);
+}
+
+function setupEvents() {
+    elements.filtersForm?.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const data = new FormData(event.target);
+        const filters = Object.fromEntries(data.entries());
+        const filtered = races.filter((race) => applyFilter(race, filters));
+        renderResults(filtered);
+    });
+
+    elements.filtersForm?.addEventListener("reset", () => {
+        setTimeout(() => renderResults(races), 0);
+    });
+
+    elements.viewToggleButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+            const view = button.dataset.view;
+            elements.viewToggleButtons.forEach((btn) => btn.setAttribute("aria-pressed", btn === button ? "true" : "false"));
+            if (view === "map") {
+                elements.mapViewWrapper.classList.remove("hidden");
+                elements.listView.classList.add("hidden");
+                setTimeout(() => appState.map?.invalidateSize(), 200);
+            } else {
+                elements.mapViewWrapper.classList.add("hidden");
+                elements.listView.classList.remove("hidden");
+            }
+        });
+    });
+
+    elements.langToggle?.addEventListener("click", () => {
+        appState.lang = appState.lang === "es" ? "en" : "es";
+        localStorage.setItem("cpm-lang", appState.lang);
+        applyTranslations();
+        renderResults(races);
+        renderFavorites();
+    });
+
+    elements.reminderForm?.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!event.target.checkValidity()) {
+            alert(translations[appState.lang].reminderError);
+            return;
+        }
+        event.target.reset();
+        alert(translations[appState.lang].reminderSuccess);
+    });
+
+    elements.downloadButton?.addEventListener("click", downloadCalendar);
+
+    elements.organizerForm?.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!event.target.checkValidity()) {
+            alert(translations[appState.lang].formError);
+            return;
+        }
+        event.target.reset();
+        alert(translations[appState.lang].formSuccess);
+    });
+
+    elements.menuToggle?.addEventListener("click", () => {
+        const expanded = elements.menuToggle.getAttribute("aria-expanded") === "true";
+        elements.menuToggle.setAttribute("aria-expanded", String(!expanded));
+        elements.mainNav.classList.toggle("open");
+    });
+}
+
+function applyFilter(race, filters) {
+    if (filters.state && race.state !== filters.state) return false;
+    if (filters.raceType && race.type !== filters.raceType) return false;
+    if (filters.distance) {
+        const distanceMatch = filters.distance === "ultra"
+            ? race.distances.some((distance) => distance >= 50)
+            : race.distances.includes(Number(filters.distance));
+        if (!distanceMatch) return false;
+    }
+    if (filters.difficulty && race.difficulty !== filters.difficulty) return false;
+    if (filters.date && race.date !== filters.date) return false;
+    if (filters.keywords) {
+        const keywords = filters.keywords.toLowerCase();
+        const haystack = `${race.name} ${race.city} ${race.state} ${race.description}`.toLowerCase();
+        if (!haystack.includes(keywords)) return false;
+    }
+    return true;
+}
+
+function initMap() {
+    if (!elements.mapContainer) return;
+    appState.map = L.map("race-map", {
+        center: [23.6345, -102.5528],
+        zoom: 5,
+        scrollWheelZoom: false
+    });
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution: "© OpenStreetMap contributors"
+    }).addTo(appState.map);
+
+    updateMapMarkers(races);
+}
+
+function updateMapMarkers(data) {
+    if (!appState.map) return;
+    appState.markers.forEach((marker) => marker.remove());
+    appState.markers = data.map((race) => {
+        const marker = L.marker(race.coordinates).addTo(appState.map);
+        marker.bindPopup(`
+            <strong>${race.name}</strong><br>
+            ${race.city}, ${race.state}<br>
+            ${formatDate(race.date)}
+        `);
+        return marker;
+    });
+}
+
+function attachFavoriteEvents() {
+    document.querySelectorAll(".favorite-btn").forEach((button) => {
+        button.addEventListener("click", () => {
+            const raceId = Number(button.dataset.id);
+            toggleFavorite(raceId);
+            button.textContent = isFavorite(raceId)
+                ? translations[appState.lang].removeFavorite
+                : translations[appState.lang].saveFavorite;
+        });
+    });
+}
+
+function toggleFavorite(id) {
+    if (isFavorite(id)) {
+        appState.favorites = appState.favorites.filter((favoriteId) => favoriteId !== id);
+    } else {
+        appState.favorites.push(id);
+    }
+    localStorage.setItem("cpm-favorites", JSON.stringify(appState.favorites));
+    renderFavorites();
+}
+
+function isFavorite(id) {
+    return appState.favorites.includes(id);
+}
+
+function renderFavorites() {
+    if (!elements.favoritesList) return;
+    elements.favoritesList.innerHTML = "";
+    const favoriteRaces = races.filter((race) => isFavorite(race.id));
+    elements.favoritesEmpty.hidden = favoriteRaces.length > 0;
+
+    favoriteRaces.forEach((race) => {
+        const item = document.createElement("li");
+        item.innerHTML = `
+            <div class="favorite-item">
+                <span>${race.name} — ${formatDate(race.date)}</span>
+                <div>
+                    <button class="btn secondary remove-favorite" data-id="${race.id}">${translations[appState.lang].removeFavorite}</button>
+                    <a class="btn primary" href="https://wa.me/?text=${encodeURIComponent(`${race.name} ${race.url}`)}" target="_blank" rel="noopener">${translations[appState.lang].favoritesShare}</a>
+                </div>
+            </div>
+        `;
+        elements.favoritesList.append(item);
+    });
+
+    elements.favoritesList.querySelectorAll(".remove-favorite").forEach((button) => {
+        button.addEventListener("click", () => {
+            const raceId = Number(button.dataset.id);
+            toggleFavorite(raceId);
+            renderResults(races);
+        });
+    });
+}
+
+function attachShareEvents() {
+    document.querySelectorAll(".share-btn").forEach((button) => {
+        button.addEventListener("click", async () => {
+            const shareData = {
+                title: button.dataset.name,
+                text: `${button.dataset.name} — Corre por México`,
+                url: button.dataset.url
+            };
+            if (navigator.share) {
+                try {
+                    await navigator.share(shareData);
+                } catch (error) {
+                    console.warn("Share cancelled", error);
+                }
+            } else {
+                navigator.clipboard?.writeText(`${button.dataset.name} ${button.dataset.url}`);
+                alert(appState.lang === "es" ? "Enlace copiado al portapapeles" : "Link copied to clipboard");
+            }
+        });
+    });
+}
+
+function downloadCalendar() {
+    const favoriteRaces = races.filter((race) => isFavorite(race.id));
+    const events = favoriteRaces.length ? favoriteRaces : races.slice(0, 3);
+    const icsContent = `BEGIN:VCALENDAR\nVERSION:2.0\nCALSCALE:GREGORIAN\nMETHOD:PUBLISH\nPRODID:-//Corre por México//Calendario//ES\n${events
+        .map((race) => {
+            const start = race.date.replace(/-/g, "");
+            return `BEGIN:VEVENT\nUID:${race.id}@correpormexico\nDTSTAMP:${start}T120000Z\nDTSTART;VALUE=DATE:${start}\nSUMMARY:${race.name}\nDESCRIPTION:${race.description}\nLOCATION:${race.city}, ${race.state}\nURL:${race.url}\nEND:VEVENT`;
+        })
+        .join("\n")}\nEND:VCALENDAR`;
+
+    const blob = new Blob([icsContent], { type: "text/calendar" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "corre-por-mexico-calendario.ics";
+    document.body.append(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    alert(translations[appState.lang].calendarDownloadSuccess);
+}
+
+function handleCookies() {
+    if (!elements.cookieBanner) return;
+    const consent = localStorage.getItem("cpm-cookies");
+    if (consent) {
+        elements.cookieBanner.style.display = "none";
+        return;
+    }
+    elements.cookieBanner.querySelectorAll("button").forEach((button) => {
+        button.addEventListener("click", () => {
+            localStorage.setItem("cpm-cookies", button.dataset.action);
+            elements.cookieBanner.style.display = "none";
+        });
+    });
+}
+
+function formatDate(date) {
+    const locale = appState.lang === "es" ? "es-MX" : "en-US";
+    return new Date(date).toLocaleDateString(locale, {
+        year: "numeric",
+        month: "short",
+        day: "numeric"
+    });
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Corre por México | Carreras en todo el país</title>
+    <meta name="description" content="Descubre carreras en todo México, inscríbete, guarda tus favoritas y organiza tus eventos con Corre por México.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2qqXSGFm3B7spaV0Uy76Ik+qHLLP/7eP1F5c7/qvu1S6Wr5mQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kP5lG1JtDxhJ4Y4x5K5hV4sHnVf1pQtP5JqLk=" crossorigin=""/>
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Saltar al contenido principal</a>
+    <header class="site-header" aria-label="Cabecera principal">
+        <div class="logo" role="banner">
+            <img src="assets/img/logo-placeholder.svg" alt="Logotipo de Corre por México" aria-hidden="true">
+            <div class="logo-text">
+                <span class="logo-title" data-i18n="siteName">Corre por México</span>
+                <span class="logo-tagline" data-i18n="siteTagline">La plataforma que conecta a la banda corredora</span>
+            </div>
+        </div>
+        <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="visually-hidden" data-i18n="openMenu">Abrir menú</span>
+            <i class="fa-solid fa-bars"></i>
+        </button>
+        <nav id="primary-navigation" class="main-nav" aria-label="Navegación principal">
+            <ul>
+                <li><a href="#buscador" data-i18n="navExplore">Explora carreras</a></li>
+                <li><a href="#mapa" data-i18n="navMap">Mapa</a></li>
+                <li><a href="#comunidad" data-i18n="navCommunity">Comunidad</a></li>
+                <li><a href="#organizadores" data-i18n="navOrganizers">Organizadores</a></li>
+                <li><a href="#soporte" data-i18n="navSupport">Soporte</a></li>
+            </ul>
+        </nav>
+        <div class="header-actions">
+            <button class="lang-toggle" data-lang="es" aria-live="polite">
+                <span class="lang-label">ES</span>
+                <span class="visually-hidden" data-i18n="toggleLang">Cambiar idioma</span>
+            </button>
+            <a class="cta" href="#buscador" data-i18n="ctaJoin">Inscríbete ahora</a>
+        </div>
+    </header>
+
+    <main id="main">
+        <section class="hero" aria-labelledby="hero-title">
+            <div class="hero-content">
+                <h1 id="hero-title" data-i18n="heroTitle">Encuentra carreras chidas en todo México</h1>
+                <p data-i18n="heroSubtitle">Conecta con la comunidad corredora, arma tu calendario y vive cada meta como si fuera una fiesta.</p>
+                <div class="hero-actions">
+                    <a class="btn primary" href="#buscador" data-i18n="heroExplore">Explora carreras</a>
+                    <a class="btn secondary" href="#comunidad" data-i18n="heroCommunity">Únete a la banda</a>
+                </div>
+            </div>
+            <div class="hero-illustration" role="presentation" aria-hidden="true">
+                <img src="https://images.unsplash.com/photo-1526406915894-7bcd65f60845?auto=format&fit=crop&w=900&q=80" alt="Corredores celebrando en una carrera" loading="lazy">
+            </div>
+        </section>
+
+        <section class="filters" id="buscador" aria-labelledby="filters-title">
+            <div class="section-heading">
+                <h2 id="filters-title" data-i18n="filtersTitle">Busca tu siguiente reto</h2>
+                <p data-i18n="filtersDescription">Usa el buscador avanzado para encontrar carreras por estado, distancia, fecha y nivel. ¡Hay opciones para toda la familia!</p>
+            </div>
+            <form class="filters-form" aria-describedby="filters-help">
+                <div class="form-group">
+                    <label for="state" data-i18n="filterState">Estado</label>
+                    <select id="state" name="state">
+                        <option value="" data-i18n="optionAny">Cualquiera</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="raceType" data-i18n="filterType">Tipo de carrera</label>
+                    <select id="raceType" name="raceType">
+                        <option value="" data-i18n="optionAny">Cualquiera</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="distance" data-i18n="filterDistance">Distancia</label>
+                    <select id="distance" name="distance">
+                        <option value="" data-i18n="optionAny">Cualquiera</option>
+                        <option value="5">5K</option>
+                        <option value="10">10K</option>
+                        <option value="21">Medio maratón</option>
+                        <option value="42">Maratón</option>
+                        <option value="ultra">Ultra</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="difficulty" data-i18n="filterDifficulty">Dificultad</label>
+                    <select id="difficulty" name="difficulty">
+                        <option value="" data-i18n="optionAny">Cualquiera</option>
+                        <option value="beginner" data-i18n="difficultyBeginner">Principiante</option>
+                        <option value="intermediate" data-i18n="difficultyIntermediate">Intermedia</option>
+                        <option value="advanced" data-i18n="difficultyAdvanced">Avanzada</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="date" data-i18n="filterDate">Fecha</label>
+                    <input type="date" id="date" name="date">
+                </div>
+                <div class="form-group full-width">
+                    <label for="keywords" data-i18n="filterKeywords">Palabras clave</label>
+                    <input type="search" id="keywords" name="keywords" placeholder="Busca por ciudad, nombre o vibes" data-i18n-placeholder="filterKeywordsPlaceholder">
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="btn primary" data-i18n="filterApply">Aplicar filtros</button>
+                    <button type="reset" class="btn secondary" data-i18n="filterReset">Limpiar</button>
+                </div>
+                <p id="filters-help" class="filters-help" data-i18n="filtersHelp">Puedes combinar varios filtros para encontrar la carrera perfecta.</p>
+            </form>
+        </section>
+
+        <section class="results" aria-labelledby="results-title">
+            <div class="results-header">
+                <div>
+                    <h2 id="results-title" data-i18n="resultsTitle">Resultados destacados</h2>
+                    <p class="results-count" aria-live="polite"></p>
+                </div>
+                <div class="view-toggle" role="group" aria-label="Cambiar vista">
+                    <button type="button" class="btn tertiary" data-view="list" aria-pressed="true" data-i18n="viewList">Vista lista</button>
+                    <button type="button" class="btn tertiary" data-view="map" aria-pressed="false" data-i18n="viewMap">Vista mapa</button>
+                </div>
+            </div>
+            <div class="results-body">
+                <div class="list-view" role="list" aria-label="Lista de carreras"></div>
+                <div class="map-view hidden" id="mapa" aria-label="Mapa de carreras">
+                    <div id="race-map" role="application" aria-label="Mapa interactivo de carreras"></div>
+                </div>
+            </div>
+        </section>
+
+        <section class="calendar" aria-labelledby="calendar-title">
+            <div class="section-heading">
+                <h2 id="calendar-title" data-i18n="calendarTitle">Tu calendario y favoritos</h2>
+                <p data-i18n="calendarDescription">Guarda carreras, descarga tu plan en PDF o iCal y recibe recordatorios por correo o WhatsApp.</p>
+            </div>
+            <div class="calendar-grid">
+                <div class="calendar-panel">
+                    <h3 data-i18n="favoritesTitle">Tus carreras favoritas</h3>
+                    <ul class="favorites-list" aria-live="polite"></ul>
+                    <p class="favorites-empty" data-i18n="favoritesEmpty">Aún no tienes favoritas. Guarda tus carreras top para no olvidarlas.</p>
+                </div>
+                <div class="calendar-panel">
+                    <h3 data-i18n="remindersTitle">Recordatorios personalizados</h3>
+                    <form class="reminder-form">
+                        <div class="form-group">
+                            <label for="reminder-email" data-i18n="reminderEmail">Correo electrónico</label>
+                            <input type="email" id="reminder-email" name="email" required placeholder="tucorreo@ejemplo.com">
+                        </div>
+                        <div class="form-group">
+                            <label for="reminder-whatsapp" data-i18n="reminderWhatsApp">WhatsApp (opcional)</label>
+                            <input type="tel" id="reminder-whatsapp" name="whatsapp" placeholder="+52 55 1234 5678">
+                        </div>
+                        <div class="form-group">
+                            <label for="reminder-frequency" data-i18n="reminderFrequency">Frecuencia de avisos</label>
+                            <select id="reminder-frequency" name="frequency">
+                                <option value="weekly" data-i18n="reminderWeekly">Semanal</option>
+                                <option value="biweekly" data-i18n="reminderBiweekly">Cada 15 días</option>
+                                <option value="monthly" data-i18n="reminderMonthly">Mensual</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn primary" data-i18n="reminderSubmit">Recibir recordatorios</button>
+                    </form>
+                    <button type="button" class="btn download" data-i18n="downloadCalendar">Descargar calendario (iCal)</button>
+                </div>
+            </div>
+        </section>
+
+        <section class="organizers" id="organizadores" aria-labelledby="organizers-title">
+            <div class="section-heading">
+                <h2 id="organizers-title" data-i18n="organizersTitle">Zona para organizadores</h2>
+                <p data-i18n="organizersDescription">Registra tus carreras con toda la información necesaria. Nosotros nos encargamos de difundirla con la comunidad corredora.</p>
+            </div>
+            <form class="organizer-form" aria-describedby="organizers-help">
+                <div class="form-group">
+                    <label for="race-name" data-i18n="organizerRaceName">Nombre del evento</label>
+                    <input type="text" id="race-name" name="race-name" required>
+                </div>
+                <div class="form-group">
+                    <label for="race-location" data-i18n="organizerLocation">Lugar</label>
+                    <input type="text" id="race-location" name="race-location" required>
+                </div>
+                <div class="form-group">
+                    <label for="race-date" data-i18n="organizerDate">Fecha</label>
+                    <input type="date" id="race-date" name="race-date" required>
+                </div>
+                <div class="form-group">
+                    <label for="race-types" data-i18n="organizerTypes">Tipos de carrera</label>
+                    <input type="text" id="race-types" name="race-types" placeholder="5K, 10K, Trail, etc." required>
+                </div>
+                <div class="form-group">
+                    <label for="race-distance" data-i18n="organizerDistances">Distancias</label>
+                    <input type="text" id="race-distance" name="race-distance" required>
+                </div>
+                <div class="form-group">
+                    <label for="race-price" data-i18n="organizerPrices">Rango de precios</label>
+                    <input type="text" id="race-price" name="race-price" placeholder="$450 - $900 MXN" required>
+                </div>
+                <div class="form-group">
+                    <label for="race-link" data-i18n="organizerLink">Enlace de inscripción</label>
+                    <input type="url" id="race-link" name="race-link" required>
+                </div>
+                <div class="form-group">
+                    <label for="race-images" data-i18n="organizerImages">Imágenes del evento</label>
+                    <input type="file" id="race-images" name="race-images" accept="image/*" multiple>
+                </div>
+                <div class="form-group">
+                    <label for="race-sponsors" data-i18n="organizerSponsors">Patrocinadores</label>
+                    <input type="text" id="race-sponsors" name="race-sponsors" placeholder="Escribe tus patrocinadores principales">
+                </div>
+                <div class="form-group full-width">
+                    <label for="race-description" data-i18n="organizerDescription">Descripción y beneficios</label>
+                    <textarea id="race-description" name="race-description" rows="5" placeholder="Comparte la historia de tu carrera y lo que la hace única"></textarea>
+                </div>
+                <button type="submit" class="btn primary" data-i18n="organizerSubmit">Enviar carrera</button>
+                <p id="organizers-help" class="form-help" data-i18n="organizersHelp">Nuestro equipo revisará la información para asegurar el cumplimiento con PROFECO y CONAR.</p>
+            </form>
+        </section>
+
+        <section class="community" id="comunidad" aria-labelledby="community-title">
+            <div class="section-heading">
+                <h2 id="community-title" data-i18n="communityTitle">Comunidad y entrenamiento</h2>
+                <p data-i18n="communityDescription">Historias, tips de entrenamiento, foros de preguntas y testimonios que inspiran a correr en tribu.</p>
+            </div>
+            <div class="community-grid">
+                <article class="card" aria-label="Blog de entrenamiento">
+                    <h3 data-i18n="communityBlogTitle">Blog y artículos</h3>
+                    <p data-i18n="communityBlogDescription">Lee guías de entrenamientos, nutrición y carreras legendarias, con lenguaje cercano y ejemplos de todo México.</p>
+                    <a href="#" class="btn tertiary" data-i18n="communityBlogCta">Ir al blog</a>
+                </article>
+                <article class="card" aria-label="Foros de la comunidad">
+                    <h3 data-i18n="communityForumTitle">Foros y preguntas</h3>
+                    <p data-i18n="communityForumDescription">Comparte dudas, arma tus grupos de entrenamiento y recibe apoyo de la banda en tu región.</p>
+                    <a href="#" class="btn tertiary" data-i18n="communityForumCta">Entrar a los foros</a>
+                </article>
+                <article class="card" aria-label="Testimonios">
+                    <h3 data-i18n="communityTestimonialsTitle">Testimonios chidos</h3>
+                    <ul class="testimonials">
+                        <li>
+                            <blockquote>
+                                <p data-i18n="testimonial1">“Gracias a Corre por México corrí mi primer 10K en Oaxaca. La vibra fue increíble.”</p>
+                                <cite>– Fernanda, Oaxaca</cite>
+                            </blockquote>
+                        </li>
+                        <li>
+                            <blockquote>
+                                <p data-i18n="testimonial2">“La comunidad me ayudó a armar mi calendario trail en Chihuahua. ¡Pura buena onda!”</p>
+                                <cite>– Luis, Chihuahua</cite>
+                            </blockquote>
+                        </li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="payments" aria-labelledby="payments-title">
+            <div class="section-heading">
+                <h2 id="payments-title" data-i18n="paymentsTitle">Pagos flexibles y locales</h2>
+                <p data-i18n="paymentsDescription">Aceptamos tarjetas, SPEI, PayPal, OXXO y 7-Eleven para que puedas inscribirte sin complicaciones.</p>
+            </div>
+            <div class="payment-methods" role="list">
+                <div class="payment-card" role="listitem">
+                    <i class="fa-solid fa-credit-card" aria-hidden="true"></i>
+                    <span data-i18n="paymentCard">Tarjeta de crédito y débito</span>
+                </div>
+                <div class="payment-card" role="listitem">
+                    <i class="fa-solid fa-building-columns" aria-hidden="true"></i>
+                    <span data-i18n="paymentSpei">Transferencia SPEI</span>
+                </div>
+                <div class="payment-card" role="listitem">
+                    <i class="fa-brands fa-paypal" aria-hidden="true"></i>
+                    <span>PayPal</span>
+                </div>
+                <div class="payment-card" role="listitem">
+                    <i class="fa-solid fa-store" aria-hidden="true"></i>
+                    <span data-i18n="paymentOxxo">Pagos en OXXO</span>
+                </div>
+                <div class="payment-card" role="listitem">
+                    <i class="fa-solid fa-store" aria-hidden="true"></i>
+                    <span data-i18n="paymentSeven">Pagos en 7-Eleven</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="support" id="soporte" aria-labelledby="support-title">
+            <div class="section-heading">
+                <h2 id="support-title" data-i18n="supportTitle">Soporte y redes sociales</h2>
+                <p data-i18n="supportDescription">Comparte carreras, recibe ayuda y mantente al día con nuestras redes.</p>
+            </div>
+            <div class="support-grid">
+                <a class="support-card" href="https://www.facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                    <i class="fa-brands fa-facebook"></i>
+                    <span>Facebook</span>
+                </a>
+                <a class="support-card" href="https://www.instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+                    <i class="fa-brands fa-instagram"></i>
+                    <span>Instagram</span>
+                </a>
+                <a class="support-card" href="https://www.youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <i class="fa-brands fa-youtube"></i>
+                    <span>YouTube</span>
+                </a>
+                <a class="support-card" href="https://wa.me/5215555555555" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp">
+                    <i class="fa-brands fa-whatsapp"></i>
+                    <span>WhatsApp</span>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer" aria-labelledby="footer-title">
+        <div class="footer-content">
+            <div>
+                <h2 id="footer-title" data-i18n="footerTitle">Corre por México</h2>
+                <p data-i18n="footerDescription">Celebramos la diversidad de rutas, culturas y tradiciones que hacen grande a nuestra comunidad corredora.</p>
+            </div>
+            <div class="footer-links">
+                <a href="#" data-i18n="footerPrivacy">Aviso de Privacidad</a>
+                <a href="#" data-i18n="footerTerms">Términos y Condiciones</a>
+                <a href="#" data-i18n="footerCookies">Cookies y preferencias</a>
+                <a href="#" data-i18n="footerAccessibility">Accesibilidad</a>
+            </div>
+            <div class="footer-meta">
+                <p data-i18n="footerRights">© <span id="year"></span> Corre por México. Todos los derechos reservados.</p>
+                <p data-i18n="footerCompliance">Cumplimos con la normatividad de PROFECO y CONAR para proteger a nuestra comunidad.</p>
+            </div>
+        </div>
+    </footer>
+
+    <div class="cookie-banner" role="dialog" aria-live="polite" aria-label="Aviso de cookies">
+        <p data-i18n="cookiesMessage">Usamos cookies para mejorar tu experiencia y cumplir con la normatividad mexicana. ¿Las aceptas?</p>
+        <div class="cookie-actions">
+            <button class="btn primary" data-action="accept" data-i18n="cookiesAccept">Aceptar</button>
+            <button class="btn secondary" data-action="reject" data-i18n="cookiesReject">Configurar</button>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kP5lG1JtDxhJ4Y4x5K5hV4sHnVf1pQtP5JqLk=" crossorigin=""></script>
+    <script src="assets/js/app.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a mobile-first Corre por México landing page with hero, advanced filters, results list, and interactive map view
- implement multilingual interface, favorites calendar tools, organizer submission form, and community, payment, and support sections
- style the site with a patriotic color palette, rounded cards, and accessible interactions, plus add client-side logic for filters, favorites, reminders, and cookie consent

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4636abe808330aa598965d45f40fc